### PR TITLE
Add ability to add additional options for pipenv install

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -10,6 +10,9 @@ inputs:
   fetch-depth:
     description: 'How deep to fetch commits'
     default: 1
+  pipenv-install-options:
+    description: "Pipenv install options"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -26,7 +29,7 @@ runs:
       python -m pip install --upgrade pip pipenv
       pipenv --python $(which python)
       pipenv run python --version
-      pipenv install --dev
+      pipenv install --dev ${{ inputs.pipenv-install-options }}
   - name: Run ${{ inputs.command }}
     shell: bash
     run:  pipenv run ${{ inputs.command }}

--- a/.github/workflows/linters-python.yml
+++ b/.github/workflows/linters-python.yml
@@ -8,6 +8,11 @@ on:
         default: false
         required: false
         type: boolean
+      pipenv-install-options:
+        description: 'Pipenv installation options'
+        default: ""
+        required: false
+        type: string
       requirements:
         description: 'Requirements file name'
         default: 'requirements-lint.txt'
@@ -83,6 +88,7 @@ jobs:
       if: ${{ inputs.pipenv == true }}
       with:
         python-version: ${{ inputs.python-version }}
+        pipenv-install-options: ${{ inputs.pipenv-install-options }}
         command: pycodestyle src/ tests/
 
   black:
@@ -99,6 +105,7 @@ jobs:
       if: ${{ inputs.pipenv == true }}
       with:
         python-version: ${{ inputs.python-version }}
+        pipenv-install-options: ${{ inputs.pipenv-install-options }}
         command: black --diff --check src/ tests/
 
   mypy:
@@ -117,6 +124,7 @@ jobs:
         if: ${{ inputs.pipenv == true }}
         with:
           python-version: ${{ inputs.python-version }}
+          pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: mypy src/ tests/
 
 
@@ -134,6 +142,7 @@ jobs:
         if: ${{ inputs.pipenv == true }}
         with:
           python-version: ${{ inputs.python-version }}
+          pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: pylint src/ tests
 
   rst:
@@ -150,4 +159,5 @@ jobs:
         if: ${{ inputs.pipenv == true }}
         with:
           python-version: ${{ inputs.python-version }}
+          pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: rst-lint *.rst

--- a/.github/workflows/tests-bump.yml
+++ b/.github/workflows/tests-bump.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: ./.github/actions/pipenv
         with:
           python-version: "3.11"
+          pipenv-install-options: "--skip-lock"
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -22,5 +23,6 @@ jobs:
       - uses: ./.github/actions/pipenv
         with:
           python-version: "3.11"
+          pipenv-install-options: "--skip-lock"
           command: towncrier check --compare-with origin/main
           fetch-depth: 0

--- a/.github/workflows/tests-pytests.yml
+++ b/.github/workflows/tests-pytests.yml
@@ -8,6 +8,11 @@ on:
         default: false
         required: false
         type: boolean
+      pipenv-install-options:
+        description: 'Pipenv installation options'
+        default: ""
+        required: false
+        type: string
       requirements:
         description: 'Requirements file name'
         default: 'requirements-test.txt'
@@ -60,6 +65,7 @@ jobs:
       if: ${{ inputs.pipenv == true }}
       with:
         python-version: ${{ matrix.python-version }}
+        pipenv-install-options: ${{ inputs.pipenv-install-options }}
         command: pytest -v --cov ${{ inputs.cover_package }} ${{ inputs.test_path }} --cov-report=xml ${{ inputs.pytest_opts }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3.1.1

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,9 @@ Lints python code
    * - pipenv
      - false
      - Whether to use pipenv or not
+   * - pipenv-install-options
+     - ""
+     - Additional pipenv install options
    * - requirements
      - requirements-lint.txt
      - Requirements file name
@@ -108,6 +111,9 @@ Run pytest tests on python code
    * - pipenv
      - false
      - Whether to use pipenv or not
+   * - pipenv-install-options
+     - ""
+     - Additional pipenv install options
    * - requirements
      - requirements-lint.txt
      - Requirements file name

--- a/newsfragments/67.feature.rst
+++ b/newsfragments/67.feature.rst
@@ -1,0 +1,2 @@
+pipenv template, linters-python and tests-pytests accepts `pipenv-install-options`
+for additional pipenv install options. Might allow adding ie. `--skip-lock`.


### PR DESCRIPTION
    This would allow to ie skip Pipefile.lock usage on certain python versions.