### PR TITLE
Add support for ruff - closes #97

### DIFF
--- a/.github/workflows/linters-python.yml
+++ b/.github/workflows/linters-python.yml
@@ -67,10 +67,20 @@ on:
         required: false
         default: false
       rst-paths:
-        description: 'Path to run black on'
+        description: 'Path to run rst on'
         type: string
         required: false
         default: "*.rst"
+      ruff:
+        description: 'Flag to run ruff linter on code or not'
+        type: boolean
+        required: false
+        default: false
+      ruff-paths:
+        description: 'Path to run ruff on'
+        type: string
+        required: false
+        default: "."
 
 jobs:
   pydocstyle:
@@ -181,3 +191,20 @@ jobs:
           python-version: ${{ inputs.python-version }}
           pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: rst-lint ${{ inputs.rst-paths }}
+
+  ruff:
+    if: ${{ inputs.ruff }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fizyk/actions-reuse/.github/actions/pip@v1.7.1
+        if: ${{ inputs.requirements != '' }}
+        with:
+          python-version: ${{ inputs.python-version }}
+          requirements: ${{ inputs.requirements }}
+          command: ruff check ${{ inputs.ruff-paths }}
+      - uses: fizyk/actions-reuse/.github/actions/pipenv@v1.7.1
+        if: ${{ inputs.requirements == '' }}
+        with:
+          python-version: ${{ inputs.python-version }}
+          pipenv-install-options: ${{ inputs.pipenv-install-options }}
+          command: ruff check ${{ inputs.ruff-paths }}

--- a/README.rst
+++ b/README.rst
@@ -95,22 +95,13 @@ Lints python code
    * - rst-paths
      - *.rst
      - Path to run rst-lint on
+   * - ruff
+     - false
+     - Flag to run ruff on code or not
+   * - ruff-paths
+     - .
+     - Path to run ruff on
 
-.. list-table:: linters that can be run
-    :header-rows: 1
-
-   * - linter
-     - default
-   * - pydocstyle
-     - yes
-   * - pycodestyle
-     - yes
-   * - black
-     - yes
-   * - mypy
-     - no
-   * - pylint
-     - no
 
 tests-pytests
 -------------

--- a/newsfragments/97.feature.rst
+++ b/newsfragments/97.feature.rst
@@ -1,0 +1,1 @@
+Added support to run ruff linter


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number