### PR TITLE
Added support to run rstcheck linter in linters workflow - closes #120

### DIFF
--- a/.github/workflows/linters-python.yml
+++ b/.github/workflows/linters-python.yml
@@ -71,6 +71,11 @@ on:
         type: string
         required: false
         default: "*.rst"
+      rstcheck:
+        description: 'Flag to run rstcheck on rst file or not'
+        type: boolean
+        required: false
+        default: false
       ruff:
         description: 'Flag to run ruff linter on code or not'
         type: boolean
@@ -191,6 +196,23 @@ jobs:
           python-version: ${{ inputs.python-version }}
           pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: rst-lint ${{ inputs.rst-paths }}
+
+  rstcheck:
+    if: ${{ inputs.rst }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fizyk/actions-reuse/.github/actions/pip@v2.1.2
+        if: ${{ inputs.requirements != '' }}
+        with:
+          python-version: ${{ inputs.python-version }}
+          requirements: ${{ inputs.requirements }}
+          command: rstcheck -r .
+      - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.1.2
+        if: ${{ inputs.requirements == '' }}
+        with:
+          python-version: ${{ inputs.python-version }}
+          pipenv-install-options: ${{ inputs.pipenv-install-options }}
+          command: rstcheck -r .
 
   ruff:
     if: ${{ inputs.ruff }}

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,9 @@ Lints python code
    * - rst-paths
      - *.rst
      - Path to run rst-lint on
+   * - rstcheck
+     - false
+     - Flag to run rstcheck on rst file or not
    * - ruff
      - false
      - Flag to run ruff on code or not

--- a/newsfragments/120.feature.rst
+++ b/newsfragments/120.feature.rst
@@ -1,0 +1,1 @@
+Added support for rstcheck rst linter


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number