### PR TITLE
Trigger rstcheck on rstcheck not rst flag

### DIFF
--- a/.github/workflows/linters-python.yml
+++ b/.github/workflows/linters-python.yml
@@ -198,7 +198,7 @@ jobs:
           command: rst-lint ${{ inputs.rst-paths }}
 
   rstcheck:
-    if: ${{ inputs.rst }}
+    if: ${{ inputs.rstcheck }}
     runs-on: ubuntu-latest
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pip@v2.2.0

--- a/newsfragments/123.bugfix.rst
+++ b/newsfragments/123.bugfix.rst
@@ -1,0 +1,1 @@
+Trigger rstcheck on rstcheck flag not rst one.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number