### PR TITLE
Cache Pipfile.lock and pipenv dependencies - closes #129

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -23,6 +23,19 @@ runs:
     uses: actions/setup-python@v4
     with:
       python-version: ${{ inputs.python-version }}
+      cache: pipenv
+  - name: Check file existence
+    id: check_files
+    uses: andstor/file-existence-action@v2
+    with:
+      files: "Pipfile.lock"
+  - name: Restore Pipfile.lock if not in git
+    if: steps.check_files.outputs.files_exists == 'false'
+    uses: actions/cache@v3
+    id: loadcache
+    with:
+      path: Pipfile.lock
+      key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
   - name: Install pipenv and dependencies
     shell: bash
     run: |
@@ -30,6 +43,13 @@ runs:
       pipenv --python $(which python)
       pipenv run python --version
       pipenv install --dev ${{ inputs.pipenv-install-options }}
+  - name: Cache Pipfile.lock if not in git
+    if: steps.check_files.outputs.files_exists == 'false'
+    uses: actions/cache/save@v3
+    id: cache
+    with:
+      path: Pipfile.lock
+      key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
   - name: Run ${{ inputs.command }}
     shell: bash
     run:  pipenv run ${{ inputs.command }}

--- a/newsfragments/129.feature.1.rst
+++ b/newsfragments/129.feature.1.rst
@@ -1,0 +1,3 @@
+Cache `Pipfile.lock` if it's not versioned in git -
+this will help provide reproducible builds, and allows
+to remove `--skip-lock` flags from pipenv install commands..

--- a/newsfragments/129.feature.rst
+++ b/newsfragments/129.feature.rst
@@ -1,0 +1,1 @@
+Cache pipenv dependencies


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number