### PR TITLE
Artifact Pipfile.lock if it's not versioned - closes #128

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -50,6 +50,12 @@ runs:
     with:
       path: Pipfile.lock
       key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
+  - name: Archive Pipfile.lock if not kept in git
+    if: steps.check_files.outputs.files_exists == 'false'
+    uses: actions/upload-artifact@v3
+    with:
+      name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
+      path: Pipfile.lock
   - name: Run ${{ inputs.command }}
     shell: bash
     run:  pipenv run ${{ inputs.command }}

--- a/newsfragments/128.feature.rst
+++ b/newsfragments/128.feature.rst
@@ -1,0 +1,1 @@
+Store Pipfile.lock as an artifact if it's not versioned.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number