### PR TITLE
Allow override Pipfile.lock artifacts

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -72,6 +72,7 @@ runs:
     with:
       name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
       path: Pipfile.lock
+      overwrite: true
   - name: Run ${{ inputs.command }}
     shell: bash
     run:  pipenv run ${{ inputs.command }}

--- a/newsfragments/172.misc.rst
+++ b/newsfragments/172.misc.rst
@@ -1,0 +1,1 @@
+Allow overriding the Pipfile.lock artifact


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number