### PR TITLE
Continue on error if artifact upload fails

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -68,6 +68,7 @@ runs:
       key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
   - name: Archive Pipfile.lock if not kept in git
     if: steps.check_files.outputs.files_exists == 'false'
+    continue-on-error: true
     uses: actions/upload-artifact@v4
     with:
       name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}

--- a/newsfragments/173.misc.rst
+++ b/newsfragments/173.misc.rst
@@ -1,0 +1,1 @@
+Allow to job to continue in case there are errors while uploading the artifact.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number