### PR TITLE
Allow pre-releases to allow tests against not-relased python versions

### DIFF
--- a/.github/actions/pip/action.yml
+++ b/.github/actions/pip/action.yml
@@ -4,6 +4,9 @@ inputs:
   python-version:  # id of input
     description: 'Python version to use'
     required: true
+  allow-prereleases:
+    description: "Allow falling back to pre-release versions of Python when a matching GA version of Python is not available."
+    required: true
   requirements:
     description: 'Requirements file name'
     default: 'requirements.txt'
@@ -22,6 +25,7 @@ runs:
     uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
+      allow-prereleases: ${{ inputs.allow-prereleases }}
       cache: pip
       cache-dependency-path: ${{ inputs.requirements }}
   - shell: bash

--- a/.github/actions/pipenv-setup/action.yml
+++ b/.github/actions/pipenv-setup/action.yml
@@ -4,6 +4,9 @@ inputs:
   python-version:  # id of input
     description: 'Python version to use'
     required: true
+  allow-prereleases:
+    description: "Allow falling back to pre-release versions of Python when a matching GA version of Python is not available."
+    required: true
   fetch-depth:
     description: 'How deep to fetch commits'
     default: 1
@@ -27,6 +30,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow-prereleases }}
         cache: pipenv
         cache-dependency-path: 'Pipfile'
     - name: Set up Python ${{ inputs.python-version }}
@@ -34,6 +38,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow-prereleases }}
     - shell: bash
       if: steps.preserve-envvars.outputs.PKG_CONFIG_PATH
       run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"

--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -4,6 +4,9 @@ inputs:
   python-version:  # id of input
     description: 'Python version to use'
     required: true
+  allow-prereleases:
+    description: "Allow falling back to pre-release versions of Python when a matching GA version of Python is not available."
+    required: true
   command:
     description: 'Command to run'
     required: true
@@ -22,6 +25,7 @@ runs:
     - uses: fizyk/actions-reuse/.github/actions/pipenv-setup@v3.1.1
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow-prereleases }}
         fetch-depth: ${{ inputs.fetch-depth }}
         pipenv-install-options: ${{ inputs.pipenv-install-options }}
         cache: ${{ inputs.cache }}

--- a/.github/workflows/shared-pr-check.yml
+++ b/.github/workflows/shared-pr-check.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v3.1.1
         with:
           python-version: ${{ inputs.python-version }}
+          allow-prereleases: false
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -27,5 +28,6 @@ jobs:
         if: ${{ !contains(fromJSON('["dependabot[bot]","pre-commit-ci[bot]"]'), github.actor) }}
         with:
           python-version: ${{ inputs.python-version }}
+          allow-prereleases: false
           command: towncrier check --compare-with origin/${{ github.base_ref }}
           fetch-depth: 0

--- a/.github/workflows/shared-tests-pytests.yml
+++ b/.github/workflows/shared-tests-pytests.yml
@@ -27,6 +27,10 @@ on:
         default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
         required: false
         type: string
+      allow-prereleases:
+        description: "Allow falling back to pre-release versions of Python when a matching GA version of Python is not available."
+        default: true
+        type: boolean
       os:
         description: 'Operating system to run tests on'
         default: 'ubuntu-latest'
@@ -58,6 +62,7 @@ jobs:
         if: ${{ inputs.requirements != '' }}
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ inputs.allow-prereleases }}
           cache: ${{ inputs.cache }}
           requirements: ${{ inputs.requirements }}
           command: pytest -v --cov --cov-report=xml ${{ inputs.pytest_opts }}
@@ -65,6 +70,7 @@ jobs:
         if: ${{ inputs.requirements == '' }}
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ inputs.allow-prereleases }}
           cache: ${{ inputs.cache }}
           pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: pytest -v --cov --cov-report=xml ${{ inputs.pytest_opts }}

--- a/newsfragments/+9fd4917b.feature.rst
+++ b/newsfragments/+9fd4917b.feature.rst
@@ -1,0 +1,1 @@
+Add `allow-prereleases` flag which will be passed to pre-releases. This in turn allows to test code against unreleased yet python versions. (Like 3.14 at the moment)


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
