### PR TITLE
Make pipenv-setup step more universal

### DIFF
--- a/.github/actions/pipenv-setup/action.yml
+++ b/.github/actions/pipenv-setup/action.yml
@@ -58,7 +58,8 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip pipenv
-        pipenv --python $(which python)
+        PY=$(python -c "import sys; print(sys.executable)")
+        pipenv --python "$PY"
         pipenv run python --version
         pipenv install --dev ${{ inputs.pipenv-install-options }}
     - name: Cache Pipfile.lock if not in git

--- a/newsfragments/+7384ea63.feature.rst
+++ b/newsfragments/+7384ea63.feature.rst
@@ -1,0 +1,2 @@
+pipenv command is not cross-platform compatible
+by replacing unix specific `which python` with cross platform pyhon call.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
