### PR TITLE
Add support to install custom pipenv categories

### DIFF
--- a/.github/actions/pipenv-setup/action.yml
+++ b/.github/actions/pipenv-setup/action.yml
@@ -16,6 +16,9 @@ inputs:
   cache:
     description: "Cache python environment?"
     default: true
+  categories:
+    description: "Additional categories from Pipfile to install"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -53,7 +56,7 @@ runs:
       id: loadcache
       with:
         path: Pipfile.lock
-        key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
+        key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}-categories-${{ inputs.categories || 'default' }}
     - name: Install pipenv and dependencies
       shell: bash
       run: |
@@ -61,19 +64,23 @@ runs:
         PY=$(python -c "import sys; print(sys.executable)")
         pipenv --python "$PY"
         pipenv run python --version
-        pipenv install --dev ${{ inputs.pipenv-install-options }}
+        CATEGORIES_SUFFIX=""
+        if [ -n "${{ inputs.categories }}" ]; then
+          CATEGORIES_SUFFIX="--categories ${{ inputs.categories }}"
+        fi
+        pipenv install --dev $CATEGORIES_SUFFIX ${{ inputs.pipenv-install-options }}
     - name: Cache Pipfile.lock if not in git
       if: steps.check_files.outputs.files_exists == 'false'
       uses: actions/cache/save@v4
       id: cache
       with:
         path: Pipfile.lock
-        key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
+        key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}-categories-${{ inputs.categories || 'default' }}
     - name: Archive Pipfile.lock if not kept in git
       if: steps.check_files.outputs.files_exists == 'false'
       continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
-        name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
+        name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}-categories-${{ inputs.categories || 'default' }}
         path: Pipfile.lock
         overwrite: true

--- a/newsfragments/+5f04f82c.feature.rst
+++ b/newsfragments/+5f04f82c.feature.rst
@@ -1,0 +1,1 @@
+Add support to install custom categories defined in Pipfile.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can specify additional Pipfile categories to install during setup.
  * Build cache and artifact naming now reflect the selected categories for clearer traceability.

* **Documentation**
  * Added release notes documenting the custom-category install support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->