### PR TITLE
Update deprecated field, and pin actions/create-github-app-token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,16 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   directory: "/"
+  cooldown:
+    default-days: 7
   schedule:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 1
 - package-ecosystem: pip
   directory: "/"
+  cooldown:
+    default-days: 7
   schedule:
     interval: weekly
     time: "04:10"

--- a/.github/workflows/shared-release.yml
+++ b/.github/workflows/shared-release.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Impersonate update bot
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
       - name: Get GitHub App User ID
         id: get-user-id

--- a/newsfragments/+c8ad7252.misc.rst
+++ b/newsfragments/+c8ad7252.misc.rst
@@ -1,0 +1,1 @@
+Update actions/create-github-app-token and replace deprecated field.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to use a newer action version and replace a deprecated configuration field.
  * Added a cooldown setting to Dependabot to reduce reopen frequency for updates.

* **Documentation**
  * Added a news fragment noting the workflow update and deprecated-field replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->