### PR TITLE
Add Self-release workflow

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -1,0 +1,15 @@
+name: Scheduled release
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  schedule:
+    uses: ./.github/workflows/shared-release-schedule.yml
+    with:
+      dependency-manager: 'uv'
+    secrets:
+      app_id: ${{ secrets.RELEASE_APP_ID }}
+      private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/shared-release-schedule.yml
+++ b/.github/workflows/shared-release-schedule.yml
@@ -1,0 +1,73 @@
+name: Scheduled release
+
+on:
+  workflow_call:
+    inputs:
+      dependency-manager:
+        description: 'Dependency manager to use (pipenv, uv)'
+        default: 'pipenv'
+        required: false
+        type: string
+    secrets:
+      app_id:
+        description: "Github Application ID that'll be used for releasing"
+        required: true
+      private_key:
+        description: "Github Application's private key"
+        required: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.compute.outputs.should_release }}
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! latest_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "No tags found; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Latest tag: $latest_tag"
+          commit_count=$(git rev-list "${latest_tag}..HEAD" --count)
+          echo "Commits since tag: $commit_count"
+          if [ "$commit_count" -eq 0 ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base=${latest_tag#v}
+          IFS='.' read -r major minor patch <<<"$base"
+          shopt -s nullglob
+          features=(newsfragments/*.feature.rst)
+          if [ "${#features[@]}" -gt 0 ]; then
+            echo "Feature fragments found (${#features[@]}); bumping minor."
+            minor=$((minor + 1))
+            patch=0
+          else
+            echo "No feature fragments; bumping patch."
+            patch=$((patch + 1))
+          fi
+          next="${major}.${minor}.${patch}"
+          echo "Next version: $next"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: plan
+    if: needs.plan.outputs.should_release == 'true'
+    uses: ./.github/workflows/shared-release.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+      dependency-manager: ${{ inputs.dependency-manager }}
+    secrets:
+      app_id: ${{ secrets.app_id }}
+      private_key: ${{ secrets.private_key }}

--- a/newsfragments/+release-schedule.feature.rst
+++ b/newsfragments/+release-schedule.feature.rst
@@ -1,0 +1,1 @@
+Add ``shared-release-schedule`` reusable workflow: on a cron, compares ``HEAD`` against the most recent tag and triggers ``shared-release`` with the next patch version when commits exist. If any ``newsfragments/*.feature.rst`` fragments are present at the time of run, bumps the minor instead. Local ``release-schedule.yml`` runs monthly (first of the month, 06:00 UTC).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable, automated monthly release schedule (with manual trigger) that checks commits and feature fragments since the last release, computes the next semantic version, and conditionally triggers a release, forwarding required release credentials.
* **Documentation**
  * Added a release-schedule note describing the monthly behaviour and how version bumps are determined (feature fragments → minor; otherwise → patch).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fizyk/actions-reuse/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->