### PR TITLE
Pin all github actions to commit SHAs - closes #288

### DIFF
--- a/.github/actions/pip/action.yml
+++ b/.github/actions/pip/action.yml
@@ -20,9 +20,9 @@ runs:
   - id: preserve-envvars
     shell: bash
     run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> "$GITHUB_OUTPUT"
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   - name: Set up Python ${{ inputs.python-version }}
-    uses: actions/setup-python@v6
+    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
     with:
       python-version: ${{ inputs.python-version }}
       allow-prereleases: ${{ inputs.allow-prereleases }}

--- a/.github/actions/pipenv-setup/action.yml
+++ b/.github/actions/pipenv-setup/action.yml
@@ -24,7 +24,7 @@ runs:
       run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> "$GITHUB_OUTPUT"
     - name: Set up cached Python ${{ inputs.python-version }}
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
         allow-prereleases: ${{ inputs.allow-prereleases }}
@@ -32,7 +32,7 @@ runs:
         cache-dependency-path: 'Pipfile'
     - name: Set up Python ${{ inputs.python-version }}
       if: ${{ inputs.cache != 'true' }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
         allow-prereleases: ${{ inputs.allow-prereleases }}
@@ -41,12 +41,12 @@ runs:
       run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
     - name: Check file existence
       id: check_files
-      uses: andstor/file-existence-action@v3
+      uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
       with:
         files: "Pipfile.lock"
     - name: Restore Pipfile.lock if not in git
       if: steps.check_files.outputs.files_exists == 'false'
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: loadcache
       with:
         path: Pipfile.lock
@@ -64,7 +64,7 @@ runs:
         fi
     - name: Cache Pipfile.lock if not in git
       if: steps.check_files.outputs.files_exists == 'false'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache
       with:
         path: Pipfile.lock
@@ -72,7 +72,7 @@ runs:
     - name: Archive Pipfile.lock if not kept in git
       if: steps.check_files.outputs.files_exists == 'false'
       continue-on-error: true
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
         path: Pipfile.lock

--- a/.github/actions/python-build/action.yml
+++ b/.github/actions/python-build/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install build tools

--- a/.github/actions/uv-build/action.yml
+++ b/.github/actions/uv-build/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up uv and Python ${{ inputs.python-version }}
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Build a wheel package

--- a/.github/actions/uv-setup/action.yml
+++ b/.github/actions/uv-setup/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> "$GITHUB_OUTPUT"
     - name: Set up uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.cache }}

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -25,7 +25,7 @@ jobs:
           app_id: ${{ secrets.app_id }}
           private_key: ${{ secrets.private_key }}
       - name: Merge me!
-        uses: ridedott/merge-me-action@v2.10.163
+        uses: ridedott/merge-me-action@f2b305b5ce4ac8d262d2e236d772483a295eb862 # v2.10.163
         with:
           # Depending on branch protection rules, a  manually populated
           # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to
@@ -42,7 +42,7 @@ jobs:
           PRESET: DEPENDABOT_MINOR
           ENABLED_FOR_MANUAL_CHANGES: 'true'
       - name: Merge me!
-        uses: ridedott/merge-me-action@v2.10.163
+        uses: ridedott/merge-me-action@f2b305b5ce4ac8d262d2e236d772483a295eb862 # v2.10.163
         with:
           # Depending on branch protection rules, a  manually populated
           # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to

--- a/.github/workflows/shared-diagram.yml
+++ b/.github/workflows/shared-diagram.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Mermaid CLI
         run: npm install -g @mermaid-js/mermaid-cli
@@ -57,7 +57,7 @@ jobs:
           echo "message=${commit_message}" >> "${GITHUB_OUTPUT}"
 
       - name: Commit and Push
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: ${{ steps.commit_message.outputs.message }}
           file_pattern: '${{ inputs.svg_path }}/*.svg'

--- a/.github/workflows/shared-pr-check.yml
+++ b/.github/workflows/shared-pr-check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.1.2
         if: ${{ inputs.dependency-manager == 'uv' }}
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.1.2

--- a/.github/workflows/shared-pre-commit.yml
+++ b/.github/workflows/shared-pre-commit.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install pre-commit

--- a/.github/workflows/shared-pypi.yml
+++ b/.github/workflows/shared-pypi.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: fizyk/actions-reuse/.github/actions/python-build@v5.1.2
         if: ${{ inputs.dependency-manager != 'uv' }}
         with:
@@ -44,13 +44,13 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Store distributions 📦 as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: package
           path: dist/
       - name: Publish distribution 📦 to PyPI
         if: ${{ inputs.publish }}
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: ${{ secrets.pypi_token }}
           verbose: true

--- a/.github/workflows/shared-release-schedule.yml
+++ b/.github/workflows/shared-release-schedule.yml
@@ -23,7 +23,7 @@ jobs:
       should_release: ${{ steps.compute.outputs.should_release }}
       version: ${{ steps.compute.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/shared-release.yml
+++ b/.github/workflows/shared-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Impersonate update bot
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ secrets.app_id }}
@@ -37,7 +37,7 @@ jobs:
       - run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/shared-tests-pytests.yml
+++ b/.github/workflows/shared-tests-pytests.yml
@@ -69,7 +69,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.1.2
@@ -90,7 +90,7 @@ jobs:
           env: ${{ inputs.env }}
           editable: ${{ inputs.install_editable }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests

--- a/newsfragments/288.bugfix.rst
+++ b/newsfragments/288.bugfix.rst
@@ -1,0 +1,1 @@
+Pin all GitHub Actions references to commit SHAs (supply-chain hardening)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated GitHub Actions workflow dependencies to use pinned commit references, enhancing build reproducibility and consistency across automated processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fizyk/actions-reuse/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->