### PR TITLE
Use persist-credentials: false throghout workflows and actions - clos…

### DIFF
--- a/.github/actions/pip/action.yml
+++ b/.github/actions/pip/action.yml
@@ -21,6 +21,8 @@ runs:
     shell: bash
     run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> "$GITHUB_OUTPUT"
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    with:
+      persist-credentials: false
   - name: Set up Python ${{ inputs.python-version }}
     uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
     with:

--- a/.github/workflows/shared-pr-check.yml
+++ b/.github/workflows/shared-pr-check.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.2.0
         if: ${{ inputs.dependency-manager == 'uv' }}
         with:
@@ -36,6 +38,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.2.0
         if: ${{ inputs.dependency-manager == 'uv' && !contains(fromJSON('["dependabot[bot]","pre-commit-ci[bot]"]'), github.actor) }}

--- a/.github/workflows/shared-pre-commit.yml
+++ b/.github/workflows/shared-pre-commit.yml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/shared-pypi.yml
+++ b/.github/workflows/shared-pypi.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: fizyk/actions-reuse/.github/actions/python-build@v5.2.0
         if: ${{ inputs.dependency-manager != 'uv' }}
         with:

--- a/.github/workflows/shared-tests-pytests.yml
+++ b/.github/workflows/shared-tests-pytests.yml
@@ -71,6 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: fizyk/actions-reuse/.github/actions/uv@v5.2.0
         if: ${{ inputs.dependency-manager == 'uv' }}

--- a/newsfragments/290.bugfix.rst
+++ b/newsfragments/290.bugfix.rst
@@ -1,0 +1,1 @@
+Secure all non-release checkouts by setting `persist-credentials: false`.


### PR DESCRIPTION
…es #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled credential persistence during repository checkouts across CI workflows to improve security during automated runs.
  * Aligned checkout behaviour consistently for build, test and publish pipelines to reduce accidental credential exposure.
  * Added a release note fragment documenting the new secure checkout requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->