### PR TITLE
Strictly define which permissions is automerge given

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   automerge:
-    uses: fizyk/actions-reuse/.github/workflows/shared-automerge.yml@v5.2.1
+    uses: ./.github/workflows/shared-automerge.yml
     secrets:
       client_id: ${{ secrets.MERGE_APP_CLIENT_ID }}
       private_key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -25,6 +25,9 @@ jobs:
           client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.private_key }}
           permission-pull-requests: write
+          permission-contents: write
+          permission-administration: read
+          permission-metadata: read
       - name: Merge me!
         uses: ridedott/merge-me-action@f2b305b5ce4ac8d262d2e236d772483a295eb862 # v2.10.163
         with:

--- a/newsfragments/+fca12521.bugfix.rst
+++ b/newsfragments/+fca12521.bugfix.rst
@@ -1,0 +1,1 @@
+Strictly define which permission is automerge given

--- a/tbump.toml
+++ b/tbump.toml
@@ -54,8 +54,6 @@ src = ".github/workflows/shared-pypi.yml"
 src = ".github/workflows/shared-release.yml"
 [[file]]
 src = ".github/workflows/shared-tests-pytests.yml"
-[[file]]
-src = ".github/workflows/automerge.yml"
 
 # You can specify a list of commands to
 # run after the files have been patched


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automerge permissions are now explicitly defined for improved reliability and security.

* **Chores**
  * Switched automerge to use a repository-local reusable workflow.
  * Cleaned up tooling configuration to remove an obsolete workflow entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->