### PR TITLE
Add missing coverage-combine-export for uv

### DIFF
--- a/.github/actions/coverage-combine-export-uv/action.yml
+++ b/.github/actions/coverage-combine-export-uv/action.yml
@@ -1,0 +1,22 @@
+name: Coverage combine and export
+description: Combine coverage files and export XML report
+
+inputs:
+  data-file:
+    description: Coverage data file prefix (for example .coverage.serial)
+    required: true
+  output-file:
+    description: XML output filename
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Combine coverage data
+      uses: fizyk/actions-reuse/.github/actions/uv-run@v5.2.2
+      with:
+        command: python -m coverage combine --data-file=${{ inputs.data-file }} ${{ inputs.data-file }}*
+    - name: Export coverage XML
+      uses: fizyk/actions-reuse/.github/actions/uv-run@v5.2.2
+      with:
+        command: python -m coverage xml --data-file=${{ inputs.data-file }} -o ${{ inputs.output-file }}

--- a/ACTIONS.rst
+++ b/ACTIONS.rst
@@ -33,6 +33,36 @@ Example:
         output-file: coverage.xml
 
 
+coverage-combine-export-uv
+--------------------------
+
+Path: ``.github/actions/coverage-combine-export-uv/action.yml``
+
+Combine coverage files and export a single XML report using uv.
+
+.. list-table:: Inputs
+   :header-rows: 1
+
+   * - input
+     - required
+     - note
+   * - data-file
+     - yes
+     - Coverage data file prefix (for example ``.coverage.serial``)
+   * - output-file
+     - yes
+     - XML output filename
+
+Example:
+
+.. code-block:: yaml
+
+    - uses: fizyk/actions-reuse/.github/actions/coverage-combine-export-uv@v5.2.2
+      with:
+        data-file: .coverage.serial
+        output-file: coverage.xml
+
+
 uv-run
 ------
 

--- a/newsfragments/+coverage-combine-export-uv.bugfix.rst
+++ b/newsfragments/+coverage-combine-export-uv.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing `coverage-combine-export-uv` composite action to combine coverage files and export an XML report using uv.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new composite action for combining coverage data files and generating XML coverage reports.

* **Documentation**
  * Added documentation for the new coverage composite action, including usage examples and input specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->