### PR TITLE
Extends automerge with check_suite

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,12 +1,17 @@
 name: Merge me test dependencies!
 
 on:
+  # workflow_run covers in-repo Actions; check_suite covers external apps
+  # such as pre-commit.ci. See the automerge section in README.rst.
   workflow_run:
     types:
       - completed
     workflows:
       # List all required workflow names here.
       - 'Run test commands'
+  check_suite:
+    types:
+      - completed
 
 
 jobs:

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -15,7 +15,11 @@ jobs:
     name: Merge me!
     # It is often a desired behavior to merge only when a workflow execution
     # succeeds. This can be changed as needed.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Supports both trigger styles so callers can use either a workflow_run
+    # or a check_suite event without breaking: workflow_run callers keep
+    # working, while check_suite callers (recommended, see automerge.yml)
+    # also re-attempt the merge after external checks such as pre-commit.ci.
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.check_suite.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Impersonate update bot

--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,8 @@ Mind that dependabot pull requests are treated as 3rd party pull requests, hence
 
 Requires Github application to run!
 
+Trigger the caller workflow on both ``workflow_run`` and ``check_suite`` completion. ``workflow_run`` observes in-repo Actions workflows, while ``check_suite`` also observes external apps such as pre-commit.ci. Using both re-attempts the merge as each completes, so it is not raced by a slower external check.
+
 
 .. list-table:: Configuration
    :header-rows: 1

--- a/newsfragments/+automerge-check-suite.bugfix.rst
+++ b/newsfragments/+automerge-check-suite.bugfix.rst
@@ -1,0 +1,1 @@
+Trigger automerge on ``check_suite`` completion in addition to ``workflow_run``, so the merge is no longer raced by external checks such as pre-commit.ci that finish after the in-repo workflows


### PR DESCRIPTION
   Seems like the external checks are the cause of automerge not waning to merge PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automerge now also responds to completed external check suites, reducing missed or delayed merges.
  * Improved handling of slower external checks so merges are retried more reliably.
* **Documentation**
  * Updated the automerge notes to explain the additional completion signal support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->