### PR TITLE
Improve and document shared-release-schedule

### DIFF
--- a/.github/workflows/shared-release-schedule.yml
+++ b/.github/workflows/shared-release-schedule.yml
@@ -8,6 +8,11 @@ on:
         default: 'pipenv'
         required: false
         type: string
+      newsfragments-required:
+        description: 'Only release when at least one towncrier newsfragment is present'
+        default: false
+        required: false
+        type: boolean
     secrets:
       app_id:
         description: "Github Application ID that'll be used for releasing"
@@ -30,6 +35,8 @@ jobs:
           persist-credentials: false
       - id: compute
         shell: bash
+        env:
+          NEWSFRAGMENTS_REQUIRED: ${{ inputs.newsfragments-required }}
         run: |
           set -euo pipefail
           if ! latest_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
@@ -47,7 +54,13 @@ jobs:
           base=${latest_tag#v}
           IFS='.' read -r major minor patch <<<"$base"
           shopt -s nullglob
+          fragments=(newsfragments/*.rst)
           features=(newsfragments/*.feature.rst)
+          if [ "$NEWSFRAGMENTS_REQUIRED" = "true" ] && [ "${#fragments[@]}" -eq 0 ]; then
+            echo "newsfragments-required is set and no newsfragments found; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "${#features[@]}" -gt 0 ]; then
             echo "Feature fragments found (${#features[@]}); bumping minor."
             minor=$((minor + 1))

--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,62 @@ Runs release on a repository. Requires tbump to be installed and configured in d
    * - private_key
      - Github Application's private key
 
+release-schedule
+----------------
+
+.. code-block:: yaml
+
+    name: Scheduled release
+    on:
+      schedule:
+        - cron: '17 6 1 * *'
+        - cron: '17 6 * * 1'
+      workflow_dispatch: {}
+
+    jobs:
+      schedule:
+        uses: fizyk/actions-reuse/.github/workflows/shared-release-schedule.yml@v5.2.8
+        with:
+          dependency-manager: 'uv'
+        secrets:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+Computes the next version and, if warranted, runs the ``release`` workflow on a schedule
+(and on demand via ``workflow_dispatch``). Because ``schedule`` triggers only fire from
+a workflow file present on the repository's default branch, this caller has to live
+in each repository - copy the snippet above and pin it to a tag.
+
+The next version is derived from the latest ``vX.Y.Z``/``X.Y.Z`` git tag: a release
+is only planned when there are commits since that tag; the bump is *minor*
+when ``newsfragments/*.feature.rst`` fragments are present and *patch* otherwise.
+Requires tbump to be installed and configured, and a ``newsfragments`` directory managed
+by towncrier.
+
+
+.. list-table:: Configuration
+   :header-rows: 1
+
+   * - parameter
+     - default
+     - note
+   * - dependency-manager
+     - pipenv
+     - Dependency manager to use (``pipenv``, ``uv``)
+   * - newsfragments-required
+     - false
+     - Only release when at least one towncrier newsfragment is present in ``newsfragments``
+
+.. list-table:: Configuration
+   :header-rows: 1
+
+   * - secret
+     - note
+   * - app_id
+     - Github Application ID that'll be used for releasing
+   * - private_key
+     - Github Application's private key
+
 Python versions
 ---------------
 

--- a/newsfragments/+release-schedule-docs.doc.rst
+++ b/newsfragments/+release-schedule-docs.doc.rst
@@ -1,0 +1,1 @@
+Document the ``release-schedule`` workflow in the README.

--- a/newsfragments/+release-schedule-newsfragments-required.feature.rst
+++ b/newsfragments/+release-schedule-newsfragments-required.feature.rst
@@ -1,0 +1,1 @@
+Add ``newsfragments-required`` input to ``shared-release-schedule``: when ``true``, release only if a newsfragment is present. Defaults to ``false``.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `newsfragments-required` setting to scheduled releases.
  - Scheduled releases can now be blocked unless at least one Towncrier news fragment is present.
  - Default behaviour remains unchanged.

- **Documentation**
  - Updated the README with a new “release-schedule” section, including examples and configuration for the scheduled workflow and the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->