### PR TITLE
Arm native auto-merge in shared-automerge, drop merge-me-action

### DIFF
--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -13,11 +13,15 @@ on:
 jobs:
   merge-me:
     name: Merge me!
-    # It is often a desired behavior to merge only when a workflow execution
-    # succeeds. This can be changed as needed.
-    # Supports both trigger styles so callers can use either a workflow_run
-    # or a check_suite event without breaking.
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.check_suite.conclusion == 'success' }}
+    # `pull_request_target` is the cheapest trigger: arming is a one-shot
+    # action, so there is no reason to run once per finished check. The
+    # continuous integration triggers stay supported for callers that have
+    # not moved over, and there only a successful run is worth acting on.
+    #
+    # `pull_request` is deliberately absent: dependabot-triggered
+    # `pull_request` runs get a read-only token and no repository secrets,
+    # so the app token cannot be minted.
+    if: ${{ github.event_name == 'pull_request_target' || github.event.workflow_run.conclusion == 'success' || github.event.check_suite.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Impersonate update bot
@@ -43,10 +47,20 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests || github.event.check_suite.pull_requests) }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          for number in $(jq -r '.[]? | .number' <<<"$PULL_REQUESTS"); do
+          # `pull_request_target` carries a single pull request directly, the
+          # continuous integration events carry a list of the pull requests
+          # the finished run belonged to.
+          if [ -n "$PULL_REQUEST_NUMBER" ]; then
+            numbers=$PULL_REQUEST_NUMBER
+          else
+            numbers=$(jq -r '.[]? | .number' <<<"$PULL_REQUESTS")
+          fi
+
+          for number in $numbers; do
             information=$(gh pr view "$number" --json author,state,commits,reviews)
             author=$(jq -r '.author.login' <<<"$information")
             state=$(jq -r '.state' <<<"$information")

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -16,9 +16,7 @@ jobs:
     # It is often a desired behavior to merge only when a workflow execution
     # succeeds. This can be changed as needed.
     # Supports both trigger styles so callers can use either a workflow_run
-    # or a check_suite event without breaking: workflow_run callers keep
-    # working, while check_suite callers (recommended, see automerge.yml)
-    # also re-attempt the merge after external checks such as pre-commit.ci.
+    # or a check_suite event without breaking.
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.check_suite.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
@@ -30,40 +28,54 @@ jobs:
           private-key: ${{ secrets.private_key }}
           permission-pull-requests: write
           permission-contents: write
-          permission-administration: read
           permission-metadata: read
-      - name: Merge me!
-        uses: ridedott/merge-me-action@98f5cf6a9f7c0ebef4a253f9dffe6530e2c1bd7c # v2.10.174
-        with:
-          # Depending on branch protection rules, a  manually populated
-          # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to
-          # a protected branch must be used. This secret can have an arbitrary
-          # name, as an example, this repository uses `DOTTBOTT_TOKEN`.
-          #
-          # When using a custom token, it is recommended to leave the following
-          # comment for other developers to be aware of the reasoning behind it:
-          #
-          # This must be used as GitHub Actions token does not support pushing
-          # to protected branches.
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          MERGE_METHOD: MERGE
-          PRESET: DEPENDABOT_MINOR
-          ENABLED_FOR_MANUAL_CHANGES: 'true'
-      - name: Merge me!
-        uses: ridedott/merge-me-action@98f5cf6a9f7c0ebef4a253f9dffe6530e2c1bd7c # v2.10.174
-        with:
-          # Depending on branch protection rules, a  manually populated
-          # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to
-          # a protected branch must be used. This secret can have an arbitrary
-          # name, as an example, this repository uses `DOTTBOTT_TOKEN`.
-          #
-          # When using a custom token, it is recommended to leave the following
-          # comment for other developers to be aware of the reasoning behind it:
-          #
-          # This must be used as GitHub Actions token does not support pushing
-          # to protected branches.
-          GITHUB_LOGIN: pre-commit-ci
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          MERGE_METHOD: MERGE
-          PRESET: DEPENDABOT_MINOR
-          ENABLED_FOR_MANUAL_CHANGES: 'true'
+      # Arms GitHub's native auto-merge rather than merging immediately.
+      # Merging immediately races external checks that report through the
+      # Statuses API (pre-commit.ci): those land after the last workflow_run
+      # or check_suite event fires, so the merge is rejected for a pending
+      # required check and nothing triggers a retry. Auto-merge is
+      # declarative -- GitHub performs the merge once the final required
+      # check reports, whichever API it arrives through.
+      #
+      # Requires `allow_auto_merge` to be enabled on the calling repository.
+      - name: Arm auto-merge
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests || github.event.check_suite.pull_requests) }}
+        run: |
+          set -euo pipefail
+
+          for number in $(jq -r '.[]? | .number' <<<"$PULL_REQUESTS"); do
+            information=$(gh pr view "$number" --json author,state,commits)
+            author=$(jq -r '.author.login' <<<"$information")
+            state=$(jq -r '.state' <<<"$information")
+            body=$(jq -r '.commits[-1].messageBody // ""' <<<"$information")
+
+            if [ "$state" != "OPEN" ]; then
+              echo "Pull request #$number is not open: $state."
+              continue
+            fi
+
+            case "$author" in
+              app/dependabot)
+                # Equivalent of merge-me-action's DEPENDABOT_MINOR preset,
+                # read from the metadata dependabot writes into the commit
+                # message rather than parsed out of the pull request title.
+                case "$body" in
+                  *version-update:semver-major*)
+                    echo "Pull request #$number is a major version bump, skipping."
+                    continue
+                    ;;
+                esac
+                ;;
+              app/pre-commit-ci) ;;
+              *)
+                echo "Pull request #$number was created by $author, skipping."
+                continue
+                ;;
+            esac
+
+            echo "Enabling auto-merge for pull request #$number by $author."
+            gh pr merge --auto --merge "$number"
+          done

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -47,10 +47,11 @@ jobs:
           set -euo pipefail
 
           for number in $(jq -r '.[]? | .number' <<<"$PULL_REQUESTS"); do
-            information=$(gh pr view "$number" --json author,state,commits)
+            information=$(gh pr view "$number" --json author,state,commits,reviews)
             author=$(jq -r '.author.login' <<<"$information")
             state=$(jq -r '.state' <<<"$information")
             body=$(jq -r '.commits[-1].messageBody // ""' <<<"$information")
+            approvals=$(jq -r '[.reviews[] | select(.state == "APPROVED")] | length' <<<"$information")
 
             if [ "$state" != "OPEN" ]; then
               echo "Pull request #$number is not open: $state."
@@ -75,6 +76,16 @@ jobs:
                 continue
                 ;;
             esac
+
+            # Approve only when nothing has approved yet, mirroring
+            # merge-me-action's `reviews(last: 1, states: APPROVED)` check.
+            # Without this a repository requiring approvals would arm
+            # auto-merge and then wait forever, since nothing else reviews
+            # dependabot and pre-commit.ci pull requests.
+            if [ "$approvals" -eq 0 ]; then
+              echo "Approving pull request #$number."
+              gh pr review --approve "$number"
+            fi
 
             echo "Enabling auto-merge for pull request #$number by $author."
             gh pr merge --auto --merge "$number"

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -61,11 +61,12 @@ jobs:
           fi
 
           for number in $numbers; do
-            information=$(gh pr view "$number" --json author,state,commits,reviews)
+            information=$(gh pr view "$number" --json author,state,commits,reviews,autoMergeRequest)
             author=$(jq -r '.author.login' <<<"$information")
             state=$(jq -r '.state' <<<"$information")
             body=$(jq -r '.commits[-1].messageBody // ""' <<<"$information")
             approvals=$(jq -r '[.reviews[] | select(.state == "APPROVED")] | length' <<<"$information")
+            armed=$(jq -r 'if .autoMergeRequest == null then "" else "yes" end' <<<"$information")
 
             if [ "$state" != "OPEN" ]; then
               echo "Pull request #$number is not open: $state."
@@ -99,6 +100,15 @@ jobs:
             if [ "$approvals" -eq 0 ]; then
               echo "Approving pull request #$number."
               gh pr review --approve "$number"
+            fi
+
+            # `synchronize` fires on every dependabot rebase, so an already
+            # armed pull request comes back around routinely. `gh pr merge`
+            # passes any error from `enablePullRequestAutoMerge` straight
+            # through, and `set -e` would turn that into a failed run.
+            if [ -n "$armed" ]; then
+              echo "Pull request #$number already has auto-merge enabled."
+              continue
             fi
 
             echo "Enabling auto-merge for pull request #$number by $author."

--- a/.github/workflows/shared-automerge.yml
+++ b/.github/workflows/shared-automerge.yml
@@ -61,8 +61,9 @@ jobs:
           fi
 
           for number in $numbers; do
-            information=$(gh pr view "$number" --json author,state,commits,reviews,autoMergeRequest)
+            information=$(gh pr view "$number" --json author,state,commits,reviews,autoMergeRequest,headRefOid)
             author=$(jq -r '.author.login' <<<"$information")
+            head=$(jq -r '.headRefOid' <<<"$information")
             state=$(jq -r '.state' <<<"$information")
             body=$(jq -r '.commits[-1].messageBody // ""' <<<"$information")
             approvals=$(jq -r '[.reviews[] | select(.state == "APPROVED")] | length' <<<"$information")
@@ -111,6 +112,10 @@ jobs:
               continue
             fi
 
+            # The gates above were evaluated against $head, so pin the arming
+            # to it: dependabot force-pushes on rebase, and without this a
+            # push landing between the read and the call would arm a commit
+            # that was never gated.
             echo "Enabling auto-merge for pull request #$number by $author."
-            gh pr merge --auto --merge "$number"
+            gh pr merge --auto --merge --match-head-commit "$head" "$number"
           done

--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,8 @@ Requires Github application to run!
 
 Major version bumps are left alone; patch and minor bumps are armed.
 
+Pull requests without an approving review are approved by the application before auto-merge is armed, so repositories that set ``required_approving_review_count`` above zero keep merging dependency updates while still holding human pull requests for review.
+
 The workflow arms auto-merge instead of merging directly, so it does not need to run at the moment every check happens to be green. GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. Trigger the caller workflow on ``workflow_run`` and/or ``check_suite`` completion; a single event reaching this workflow is enough to arm it.
 
 

--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,18 @@ automerge
 
 .. code-block:: yaml
 
+    name: Merge me test dependencies!
+
+    on:
+      workflow_run:
+        types:
+          - completed
+        workflows:
+          - 'Run tests'
+      check_suite:
+        types:
+          - completed
+
     jobs:
       automerge:
         uses: fizyk/actions-reuse/.github/workflows/shared-automerge.yml@v5.3.2
@@ -223,7 +235,9 @@ Major version bumps are left alone; patch and minor bumps are armed.
 
 Pull requests without an approving review are approved by the application before auto-merge is armed, so repositories that set ``required_approving_review_count`` above zero keep merging dependency updates while still holding human pull requests for review.
 
-The workflow arms auto-merge instead of merging directly, so it does not need to run at the moment every check happens to be green. GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. Trigger the caller workflow on ``workflow_run`` and/or ``check_suite`` completion; a single event reaching this workflow is enough to arm it.
+The job takes the pull request from the triggering event, so the caller has to be triggered on ``workflow_run`` and/or ``check_suite`` completion; on any other event the job is skipped.
+
+Arming does not have to happen at a moment when every check is green, so one event carrying the pull request is enough. GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. There is no need to list every workflow under ``workflows:`` to avoid being raced by a slow external check.
 
 
 .. list-table:: Configuration

--- a/README.rst
+++ b/README.rst
@@ -225,17 +225,11 @@ Requires Github application to run!
 
     gh api -X PATCH repos/OWNER/REPO -F allow_auto_merge=true
 
-Major version bumps are left alone; patch and minor bumps are armed.
+Major version bumps are left alone; patch and minor bumps are armed. Pull requests with no approving review are approved first, so repositories requiring approvals keep merging dependency updates while still holding human pull requests.
 
-Pull requests without an approving review are approved by the application before auto-merge is armed, so repositories that set ``required_approving_review_count`` above zero keep merging dependency updates while still holding human pull requests for review.
+Prefer ``pull_request_target``: arming is a one-shot action, and GitHub merges once the last required check reports, whichever API it reports through. It arms as the pull request opens, which assumes required status checks are configured. ``workflow_run`` and ``check_suite`` completion also work, but run the job once per finished check. On any other event the job is skipped.
 
-The job takes the pull request from the triggering event, so the caller has to be triggered on ``pull_request_target``, or on ``workflow_run`` and/or ``check_suite`` completion. On any other event the job is skipped.
-
-Prefer ``pull_request_target``. Arming does not have to happen at a moment when every check is green, so running once per pull request is enough; GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. The continuous integration triggers remain supported for callers that have not moved over, and on those only a successful run is acted on, but they run the job once per finished check to do work that is only needed once.
-
-Do not use ``pull_request``: dependabot-triggered ``pull_request`` runs get a read-only token and no repository secrets, so the app token cannot be minted. ``pull_request_target`` runs in the base branch context with full access to secrets, which is safe here because the job never checks out pull request code.
-
-Mind that on ``pull_request_target`` the pull request is armed as soon as it is opened, before its checks have registered. This assumes the repository has required status checks configured, so that a pull request with nothing reported yet is not already mergeable.
+Do not use ``pull_request``: dependabot runs get no repository secrets there, so the app token cannot be minted.
 
 
 .. list-table:: Configuration

--- a/README.rst
+++ b/README.rst
@@ -207,14 +207,8 @@ automerge
     name: Merge me test dependencies!
 
     on:
-      workflow_run:
-        types:
-          - completed
-        workflows:
-          - 'Run tests'
-      check_suite:
-        types:
-          - completed
+      pull_request_target:
+        types: [opened, reopened, synchronize]
 
     jobs:
       automerge:
@@ -235,9 +229,13 @@ Major version bumps are left alone; patch and minor bumps are armed.
 
 Pull requests without an approving review are approved by the application before auto-merge is armed, so repositories that set ``required_approving_review_count`` above zero keep merging dependency updates while still holding human pull requests for review.
 
-The job takes the pull request from the triggering event, so the caller has to be triggered on ``workflow_run`` and/or ``check_suite`` completion; on any other event the job is skipped.
+The job takes the pull request from the triggering event, so the caller has to be triggered on ``pull_request_target``, or on ``workflow_run`` and/or ``check_suite`` completion. On any other event the job is skipped.
 
-Arming does not have to happen at a moment when every check is green, so one event carrying the pull request is enough. GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. There is no need to list every workflow under ``workflows:`` to avoid being raced by a slow external check.
+Prefer ``pull_request_target``. Arming does not have to happen at a moment when every check is green, so running once per pull request is enough; GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. The continuous integration triggers remain supported for callers that have not moved over, and on those only a successful run is acted on, but they run the job once per finished check to do work that is only needed once.
+
+Do not use ``pull_request``: dependabot-triggered ``pull_request`` runs get a read-only token and no repository secrets, so the app token cannot be minted. ``pull_request_target`` runs in the base branch context with full access to secrets, which is safe here because the job never checks out pull request code.
+
+Mind that on ``pull_request_target`` the pull request is armed as soon as it is opened, before its checks have registered. This assumes the repository has required status checks configured, so that a pull request with nothing reported yet is not already mergeable.
 
 
 .. list-table:: Configuration

--- a/README.rst
+++ b/README.rst
@@ -208,16 +208,20 @@ automerge
       automerge:
         uses: fizyk/actions-reuse/.github/workflows/shared-automerge.yml@v5.3.2
 
-Runs automerge for dependabot pull requests using:
-
-* `ridedott/merge-me-action <https://github.com/ridedott/merge-me-action>_` to run the merge
-* `tibdex/github-app-token <https://github.com/tibdex/github-app-token>`_ to generate short-lived github app token with enough permissions to run the merge.
+Arms `GitHub's native auto-merge <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request>`_ on dependabot and pre-commit.ci pull requests, using
+`actions/create-github-app-token <https://github.com/actions/create-github-app-token>`_ to generate a short-lived github app token with enough permissions to enable it.
 
 Mind that dependabot pull requests are treated as 3rd party pull requests, hence default GITHUB_TOKEN will only have read permissions.
 
 Requires Github application to run!
 
-Trigger the caller workflow on both ``workflow_run`` and ``check_suite`` completion. ``workflow_run`` observes in-repo Actions workflows, while ``check_suite`` also observes external apps such as pre-commit.ci. Using both re-attempts the merge as each completes, so it is not raced by a slower external check.
+**Requires** ``allow_auto_merge`` to be enabled on the calling repository, otherwise enabling auto-merge fails::
+
+    gh api -X PATCH repos/OWNER/REPO -F allow_auto_merge=true
+
+Major version bumps are left alone; patch and minor bumps are armed.
+
+The workflow arms auto-merge instead of merging directly, so it does not need to run at the moment every check happens to be green. GitHub performs the merge once the last required check reports, including checks that report through the Statuses API rather than the Checks API, such as pre-commit.ci. Trigger the caller workflow on ``workflow_run`` and/or ``check_suite`` completion; a single event reaching this workflow is enough to arm it.
 
 
 .. list-table:: Configuration
@@ -225,8 +229,8 @@ Trigger the caller workflow on both ``workflow_run`` and ``check_suite`` complet
 
    * - secret
      - note
-   * - app_id
-     - Github Application ID that'll be used for merging
+   * - client_id
+     - Github Application Client ID that'll be used for merging
    * - private_key
      - Github Application's private key
 

--- a/newsfragments/+automerge-allow-auto-merge-required.removal.rst
+++ b/newsfragments/+automerge-allow-auto-merge-required.removal.rst
@@ -1,0 +1,3 @@
+``shared-automerge`` now requires ``allow_auto_merge`` to be enabled on the calling repository.
+Callers that take this version without enabling it fail with "Auto-merge is not allowed for this repository".
+Enable it with ``gh api -X PATCH repos/OWNER/REPO -F allow_auto_merge=true``.

--- a/newsfragments/+automerge-merge-me-action-removal.removal.rst
+++ b/newsfragments/+automerge-merge-me-action-removal.removal.rst
@@ -1,3 +1,0 @@
-Remove the ``ridedott/merge-me-action`` dependency from ``shared-automerge``.
-The author and version-bump gates it provided are kept: only ``dependabot`` and ``pre-commit-ci`` pull requests are armed, and major version bumps are skipped, now determined from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title.
-``permission-administration: read`` is no longer requested for the app token.

--- a/newsfragments/+automerge-merge-me-action-removal.removal.rst
+++ b/newsfragments/+automerge-merge-me-action-removal.removal.rst
@@ -1,0 +1,3 @@
+Remove the ``ridedott/merge-me-action`` dependency from ``shared-automerge``.
+The author and version-bump gates it provided are kept: only ``dependabot`` and ``pre-commit-ci`` pull requests are armed, and major version bumps are skipped, now determined from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title.
+``permission-administration: read`` is no longer requested for the app token.

--- a/newsfragments/+automerge-native-auto-merge.bugfix.rst
+++ b/newsfragments/+automerge-native-auto-merge.bugfix.rst
@@ -1,0 +1,3 @@
+Arm GitHub's native auto-merge in ``shared-automerge`` instead of merging immediately.
+The previous approach still lost a race against external checks reporting through the Statuses API, such as pre-commit.ci: those land after the last ``workflow_run``/``check_suite`` event fires, so the merge was rejected for a pending required check and nothing re-triggered the workflow.
+Callers must enable ``allow_auto_merge`` on the repository.

--- a/newsfragments/+automerge-native-auto-merge.bugfix.rst
+++ b/newsfragments/+automerge-native-auto-merge.bugfix.rst
@@ -1,4 +1,3 @@
 Arm GitHub's native auto-merge in ``shared-automerge`` instead of merging immediately.
 The previous approach still lost a race against external checks reporting through the Statuses API, such as pre-commit.ci: those land after the last ``workflow_run``/``check_suite`` event fires, so the merge was rejected for a pending required check and nothing re-triggered the workflow.
 This drops the ``ridedott/merge-me-action`` dependency; the author and version-bump gates it provided are kept, now read from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title, as is its behaviour of approving pull requests that have no approving review yet.
-Callers must enable ``allow_auto_merge`` on the repository.

--- a/newsfragments/+automerge-native-auto-merge.bugfix.rst
+++ b/newsfragments/+automerge-native-auto-merge.bugfix.rst
@@ -1,3 +1,4 @@
 Arm GitHub's native auto-merge in ``shared-automerge`` instead of merging immediately.
 The previous approach still lost a race against external checks reporting through the Statuses API, such as pre-commit.ci: those land after the last ``workflow_run``/``check_suite`` event fires, so the merge was rejected for a pending required check and nothing re-triggered the workflow.
+This drops the ``ridedott/merge-me-action`` dependency; the author and version-bump gates it provided are kept, now read from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title.
 Callers must enable ``allow_auto_merge`` on the repository.

--- a/newsfragments/+automerge-native-auto-merge.bugfix.rst
+++ b/newsfragments/+automerge-native-auto-merge.bugfix.rst
@@ -1,4 +1,4 @@
 Arm GitHub's native auto-merge in ``shared-automerge`` instead of merging immediately.
 The previous approach still lost a race against external checks reporting through the Statuses API, such as pre-commit.ci: those land after the last ``workflow_run``/``check_suite`` event fires, so the merge was rejected for a pending required check and nothing re-triggered the workflow.
-This drops the ``ridedott/merge-me-action`` dependency; the author and version-bump gates it provided are kept, now read from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title.
+This drops the ``ridedott/merge-me-action`` dependency; the author and version-bump gates it provided are kept, now read from the update metadata dependabot writes into the commit message rather than parsed out of the pull request title, as is its behaviour of approving pull requests that have no approving review yet.
 Callers must enable ``allow_auto_merge`` on the repository.

--- a/newsfragments/+automerge-pull-request-target.feature.rst
+++ b/newsfragments/+automerge-pull-request-target.feature.rst
@@ -1,0 +1,3 @@
+Support triggering ``shared-automerge`` on ``pull_request_target``, which is now the preferred trigger.
+Arming auto-merge is a one-shot action, so the ``workflow_run``/``check_suite`` triggers ran the job once per finished check to do work only needed once; they remain supported.
+``pull_request`` is not supported, since dependabot-triggered ``pull_request`` runs get no repository secrets and cannot mint the app token.


### PR DESCRIPTION
## Problem

`shared-automerge` merges immediately, so it has to run at a moment when every required check is already green.

`pre-commit.ci - pr` reports through the **Statuses API**, not the Checks API — it has no check run and no check suite. On `fizyk/pyramid_basemodel#785` it went green at `04:35:22`, while the last `check_suite` event fired at `04:34:25` and the merge was attempted at `04:34:33`. GitHub rejected it for a pending required check, and since pre-commit.ci produces no check-suite completion, nothing re-triggered the workflow. The PR sat green and unmerged.

`dbfixtures/mirakuru#1118` — same day, same version, same app — merged fine only because its macOS matrix runs until `04:37:33`, giving automerge a late `workflow_run` retrigger after pre-commit.ci had already reported. Whether a repo automerges currently depends on whether its own CI happens to outlast pre-commit.ci.

Adding a `status` trigger wouldn't fix it: `merge-me-action`'s dispatcher only handles `check_suite`, `workflow_run`, `pull_request` and `pull_request_target`, and its handler reads the PR list off `workflow_run.pull_requests` / `check_suite.pull_requests`, neither of which exists on a `status` payload.

## Change

Arm GitHub's native auto-merge instead of merging. Arming early is fine — GitHub performs the merge once the last required check reports, whichever API it arrives through. No new trigger is needed, so callers don't change; this reaches all consuming repos through the usual SHA bump.

This drops `ridedott/merge-me-action`, the only non-GitHub-owned action in the privileged step. `permission-administration: read` is no longer requested either, since it was only there to let the action read branch protection rules.

## Gate parity

| merge-me-action | here |
|---|---|
| `GITHUB_LOGIN` (two steps) | `case` on `gh pr view --json author` |
| `PRESET: DEPENDABOT_MINOR` | `version-update:semver-major` check against the dependabot commit trailer |
| `MERGE_METHOD: MERGE` | `--merge` |
| `ENABLED_FOR_MANUAL_CHANGES: 'true'` | nothing to port — that guard was already disabled |
| `MAXIMUM_RETRIES: 3` | obsolete, nothing to retry |
| strict status checks | unchanged; GitHub enforces it |

Dry-run of the gate against real `pyramid_basemodel` PRs:

```
785: ARM   [app/dependabot]        784: ARM   [app/dependabot]
773: ARM   [app/pre-commit-ci]      38: SKIP   author not automerged [fizyk]
752: SKIP  major version bump      753: SKIP  major version bump
```

752/753 are the 4.4.7 → 5.1.2 bumps `DEPENDABOT_MINOR` correctly refused, so the semver gate holds.

## Required before merging

`allow_auto_merge` must be enabled on every consuming repository — `gh pr merge --auto` errors with "Auto-merge is not allowed for this repository" when it is off. It is currently `false` on all of `pyramid_basemodel`, `mirakuru`, `port-for`, `matchbox` and `pyramid_fullauth`, so **flip it across the 18 consumers first**, otherwise automerge breaks everywhere at once.

```
fizyk/*        actions-reuse, matchbox, port-for, pyproject-validator, pyramid_basemodel,
               pyramid_fullauth, pyramid_localize, pytest_pyramid, resizer
dbfixtures/*   mirakuru, pytest-dynamodb, pytest-elasticsearch, pytest-mongo,
               pytest-mysql, pytest-postgresql, pytest-rabbitmq, pytest-redis
ClearcodeHQ/*  jira_timemachine
```

## Note

The semver gate reads the commit trailer without verifying the commit signature, which `dependabot/fetch-metadata` would do. That action only runs on `pull_request`/`pull_request_target`, which a reusable workflow can't declare. Not a regression: `ENABLED_FOR_MANUAL_CHANGES: 'true'` already disabled the equivalent guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependabot and pre-commit.ci pull requests can now be queued for GitHub’s native auto-merge.
  * Auto-merge waits for all required checks to complete before merging.
  * Supports `pull_request_target`, workflow completion and check-suite events.
  * Eligible requests are approved automatically when no approval exists.

* **Bug Fixes**
  * Prevents premature merges caused by late status checks.
  * Continues to enforce patch- and minor-update restrictions.

* **Documentation**
  * Added setup guidance, repository requirements and updated authentication configuration.
  * Documents that standard pull request events are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->