### PR TITLE
Add zizmor to pre-commit and fix findings - closes #313

### DIFF
--- a/.github/actions/pip/action.yml
+++ b/.github/actions/pip/action.yml
@@ -30,14 +30,23 @@ runs:
       allow-prereleases: ${{ inputs.allow-prereleases }}
       cache: pip
       cache-dependency-path: ${{ inputs.requirements }}
+  # The value written back is PKG_CONFIG_PATH as the runner itself set it before
+  # setup-python ran, never anything a caller or a pull request can influence.
   - shell: bash
     if: steps.preserve-envvars.outputs.PKG_CONFIG_PATH
-    run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
+    env:
+      PRESERVED_PKG_CONFIG_PATH: ${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}
+    run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PRESERVED_PKG_CONFIG_PATH" >> "$GITHUB_ENV"  # zizmor: ignore[github-env]
   - name: Install dependencies
     shell: bash
+    env:
+      REQUIREMENTS: ${{ inputs.requirements }}
     run: |
       python -m pip install --upgrade pip
-      pip install -r ${{ inputs.requirements }}
+      pip install -r "$REQUIREMENTS"
+  # `command` is a shell fragment written by the calling workflow, and callers
+  # rely on shell syntax inside it (quoting, command substitution), so it has to
+  # be expanded into the script rather than passed through the environment.
   - name: Run ${{ inputs.command }}
     shell: bash
-    run:  ${{ inputs.command }}
+    run: ${{ inputs.command }}  # zizmor: ignore[template-injection]

--- a/.github/actions/pipenv-run/action.yml
+++ b/.github/actions/pipenv-run/action.yml
@@ -11,7 +11,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # `command` is a shell fragment written by the calling workflow, and callers
+    # rely on shell syntax inside it (quoting, command substitution), so it has
+    # to be expanded into the script rather than passed through the environment.
     - name: Run ${{ inputs.command }}
       shell: bash
-      run: pipenv run ${{ inputs.command }}
+      run: pipenv run ${{ inputs.command }}  # zizmor: ignore[template-injection]
       env: ${{ fromJSON(inputs.env) }}

--- a/.github/actions/pipenv-setup/action.yml
+++ b/.github/actions/pipenv-setup/action.yml
@@ -13,9 +13,6 @@ inputs:
   cache:
     description: "Cache python environment?"
     default: true
-  editable:
-    description: "Install package as editable?"
-    default: false
 runs:
   using: "composite"
   steps:
@@ -36,9 +33,14 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         allow-prereleases: ${{ inputs.allow-prereleases }}
+    # The value written back is PKG_CONFIG_PATH as the runner itself set it
+    # before setup-python ran, never anything a caller or a pull request can
+    # influence.
     - shell: bash
       if: steps.preserve-envvars.outputs.PKG_CONFIG_PATH
-      run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
+      env:
+        PRESERVED_PKG_CONFIG_PATH: ${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}
+      run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PRESERVED_PKG_CONFIG_PATH" >> "$GITHUB_ENV"  # zizmor: ignore[github-env]
     - name: Check file existence
       id: check_files
       uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
@@ -51,17 +53,19 @@ runs:
       with:
         path: Pipfile.lock
         key: pipfile-lock-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('Pipfile') }}
-    - name: Install pipenv and dependencies
+    - name: Install pipenv
       shell: bash
       run: |
         python -m pip install --upgrade pip pipenv
         PY=$(python -c "import sys; print(sys.executable)")
         pipenv --python "$PY"
         pipenv run python --version
-        pipenv install --dev ${{ inputs.pipenv-install-options }}
-        if [[ "${{ inputs.editable }}" == "true" ]]; then
-            pipenv install --editable .
-        fi
+    # `pipenv-install-options` is a shell fragment written by the calling
+    # workflow, so it is expanded into the script rather than passed through the
+    # environment, where quoting inside it would no longer be honoured.
+    - name: Install dependencies
+      shell: bash
+      run: pipenv install --dev ${{ inputs.pipenv-install-options }}  # zizmor: ignore[template-injection]
     - name: Cache Pipfile.lock if not in git
       if: steps.check_files.outputs.files_exists == 'false'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -20,9 +20,6 @@ inputs:
     description: 'JSON object string of environment variables to set'
     required: false
     default: '{}'
-  editable:
-    description: "Install package as editable?"
-    default: false
 runs:
   using: "composite"
   steps:
@@ -32,7 +29,6 @@ runs:
         allow-prereleases: ${{ inputs.allow-prereleases }}
         pipenv-install-options: ${{ inputs.pipenv-install-options }}
         cache: ${{ inputs.cache }}
-        editable: ${{ inputs.editable }}
     - uses: fizyk/actions-reuse/.github/actions/pipenv-run@v5.4.1
       with:
         command: ${{ inputs.command }}

--- a/.github/actions/uv-run/action.yml
+++ b/.github/actions/uv-run/action.yml
@@ -11,7 +11,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # `command` is a shell fragment written by the calling workflow, and callers
+    # rely on shell syntax inside it (quoting, command substitution), so it has
+    # to be expanded into the script rather than passed through the environment.
     - name: Run ${{ inputs.command }}
       shell: bash
-      run: uv run ${{ inputs.command }}
+      run: uv run ${{ inputs.command }}  # zizmor: ignore[template-injection]
       env: ${{ fromJSON(inputs.env) }}

--- a/.github/actions/uv-setup/action.yml
+++ b/.github/actions/uv-setup/action.yml
@@ -21,12 +21,22 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.cache }}
+    # The value written back is PKG_CONFIG_PATH as the runner itself set it
+    # before uv was set up, never anything a caller or a pull request can
+    # influence.
     - shell: bash
       if: steps.preserve-envvars.outputs.PKG_CONFIG_PATH
-      run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
+      env:
+        PRESERVED_PKG_CONFIG_PATH: ${{ steps.preserve-envvars.outputs.PKG_CONFIG_PATH }}
+      run: echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PRESERVED_PKG_CONFIG_PATH" >> "$GITHUB_ENV"  # zizmor: ignore[github-env]
     - name: Install Python ${{ inputs.python-version }}
       shell: bash
-      run: uv python install ${{ inputs.python-version }}
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      run: uv python install "$PYTHON_VERSION"
+    # `uv-install-options` is a shell fragment written by the calling workflow,
+    # so it is expanded into the script rather than passed through the
+    # environment, where quoting inside it would no longer be honoured.
     - name: Install dependencies
       shell: bash
-      run: uv sync --all-groups ${{ inputs.uv-install-options }}
+      run: uv sync --all-groups ${{ inputs.uv-install-options }}  # zizmor: ignore[template-injection]

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,10 @@
 name: Merge me test dependencies!
 
-on:
+# `workflow_run` and `check_suite` run against the base repository with access to
+# secrets, which is what makes them dangerous in general. Nothing here checks out
+# or executes pull request code: the shared workflow only reads pull request
+# metadata through the API and gates on it before arming auto-merge.
+on:  # zizmor: ignore[dangerous-triggers]
   # workflow_run covers in-repo Actions; check_suite covers external apps
   # such as pre-commit.ci. See the automerge section in README.rst.
   workflow_run:
@@ -13,6 +17,10 @@ on:
     types:
       - completed
 
+
+# Everything the shared workflow does goes through the merge app's token, so the
+# job token needs nothing at all.
+permissions: {}
 
 jobs:
   automerge:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   pr-check:
     uses: fizyk/actions-reuse/.github/workflows/shared-pr-check.yml@v5.4.1

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   pr-check:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pr-check.yml@v5.4.1
+    uses: ./.github/workflows/shared-pr-check.yml
     with:
       dependency-manager: 'uv'

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -5,6 +5,11 @@ on:
     - cron: '17 6 * * 1'
   workflow_dispatch: {}
 
+# The release itself is pushed with the app token minted inside the shared
+# workflow, so the job token only ever reads.
+permissions:
+  contents: read
+
 jobs:
   schedule:
     uses: ./.github/workflows/shared-release-schedule.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string
 
+# The release itself is pushed with the app token minted inside the shared
+# workflow, so the job token only ever reads.
+permissions:
+  contents: read
+
 jobs:
   release:
     uses: fizyk/actions-reuse/.github/workflows/shared-release.yml@v5.4.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    uses: fizyk/actions-reuse/.github/workflows/shared-release.yml@v5.4.1
+    uses: ./.github/workflows/shared-release.yml
     with:
       version: ${{ inputs.version }}
       dependency-manager: 'uv'

--- a/.github/workflows/shared-diagram.yml
+++ b/.github/workflows/shared-diagram.yml
@@ -27,24 +27,34 @@ jobs:
   render:
     runs-on: ubuntu-latest
     steps:
+      # git-auto-commit-action below pushes the rendered diagrams back, so this
+      # checkout has to keep its credentials. At this pin they are not written
+      # into the checkout: they live in a config file under $RUNNER_TEMP that the
+      # repository's .git/config includes.
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1  # zizmor: ignore[artipacked]
 
+      # mermaid-cli is a one-off global tool for this job, so there is no
+      # lockfile to install it from.
       - name: Install Mermaid CLI
-        run: npm install -g @mermaid-js/mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli  # zizmor: ignore[adhoc-packages]
 
       - name: Render Diagrams
+        env:
+          MMD_PATH: ${{ inputs.mmd_path }}
+          SVG_PATH: ${{ inputs.svg_path }}
+          PUPPETEER_CONFIG: ${{ inputs.puppeteer_config }}
         run: |
-          mkdir -p "${{ inputs.svg_path }}"
+          mkdir -p "${SVG_PATH}"
           shopt -s nullglob
-          files=("${{ inputs.mmd_path }}"/*.mmd)
+          files=("${MMD_PATH}"/*.mmd)
           if [ ${#files[@]} -eq 0 ]; then
-            echo "No .mmd files found in ${{ inputs.mmd_path }}; skipping."
+            echo "No .mmd files found in ${MMD_PATH}; skipping."
             exit 0
           fi
           for file in "${files[@]}"; do
             base="$(basename "${file}" .mmd)"
-            mmdc -p "${{ inputs.puppeteer_config }}" -i "${file}" -o "${{ inputs.svg_path }}/${base}.svg" -t neutral
+            mmdc -p "${PUPPETEER_CONFIG}" -i "${file}" -o "${SVG_PATH}/${base}.svg" -t neutral
           done
 
       - name: Prepare Commit Message

--- a/.github/workflows/shared-pypi.yml
+++ b/.github/workflows/shared-pypi.yml
@@ -50,9 +50,13 @@ jobs:
         with:
           name: package
           path: dist/
+      # Trusted publishing has to be configured per project on PyPI and needs an
+      # `id-token: write` grant from the caller, so this workflow keeps taking a
+      # token: callers that have moved to trusted publishing can call
+      # pypa/gh-action-pypi-publish directly instead.
       - name: Publish distribution 📦 to PyPI
         if: ${{ inputs.publish }}
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2  # zizmor: ignore[use-trusted-publishing]
         with:
           password: ${{ secrets.pypi_token }}
           verbose: true

--- a/.github/workflows/shared-release-schedule.yml
+++ b/.github/workflows/shared-release-schedule.yml
@@ -31,6 +31,11 @@ on:
         description: "Github Application's private key"
         required: true
 
+# Planning only reads the repository; the release is pushed with the app token
+# minted in shared-release.yml.
+permissions:
+  contents: read
+
 jobs:
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/shared-release.yml
+++ b/.github/workflows/shared-release.yml
@@ -23,21 +23,48 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # `version` ends up inside the shell fragment handed to tbump, and this job
+      # holds the release app's credentials, so a value that is not a version is
+      # refused before the token is minted rather than run. The character set is
+      # left wide enough for any scheme a caller's tbump regex accepts.
+      - name: Check that the version is a version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+            echo "::error::Refusing to release '$VERSION': not a version."
+            exit 1
+          fi
       - name: Impersonate update bot
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
+          # `contents` covers the version bump commit and the tag tbump pushes.
+          # `workflows` is needed on top of it because the files tbump patches
+          # include reusable workflows, and GitHub refuses a push touching
+          # `.github/workflows` from an app token without it.
+          permission-contents: write
+          permission-workflows: write
+          permission-metadata: read
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+      - env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        run: |
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+      # tbump pushes the bump commit and the tag, so this checkout has to keep
+      # its credentials. At this pin they are not written into the checkout: they
+      # live in a config file under $RUNNER_TEMP that the repository's
+      # .git/config includes.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1  # zizmor: ignore[artipacked]
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/shared-tests-pytests.yml
+++ b/.github/workflows/shared-tests-pytests.yml
@@ -42,11 +42,6 @@ on:
         default: '{}'
         required: false
         type: string
-      install_editable:
-        description: 'Whether to install in pipenv editable mode'
-        default: false
-        required: false
-        type: boolean
       dependency-manager:
         description: 'Dependency manager to use (pipenv, uv)'
         default: 'pipenv'
@@ -89,7 +84,6 @@ jobs:
           pipenv-install-options: ${{ inputs.pipenv-install-options }}
           command: pytest -v --cov --cov-report=xml ${{ inputs.pytest_opts }}
           env: ${{ inputs.env }}
-          editable: ${{ inputs.install_editable }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     uses: ./.github/workflows/shared-tests-pytests.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # This repository's own actions and reusable workflows are referenced by
+        # the version tag tbump rewrites on release, so they cannot be
+        # hash-pinned: the hash would have to be known before the commit that
+        # contains it exists.
+        fizyk/actions-reuse: ref-pin
+        fizyk/actions-reuse/*: ref-pin
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor

--- a/ACTIONS.rst
+++ b/ACTIONS.rst
@@ -288,9 +288,6 @@ Set up Python and pipenv, then install project dependencies.
    * - cache
      - no
      - ``true``
-   * - editable
-     - no
-     - ``false``
 
 Example:
 
@@ -301,7 +298,6 @@ Example:
         python-version: "3.14"
         allow-prereleases: false
         cache: true
-        editable: false
 
 
 pipenv
@@ -335,9 +331,6 @@ Set up pipenv and run a command in one step.
    * - env
      - no
      - ``{}``
-   * - editable
-     - no
-     - ``false``
 
 Example:
 

--- a/README.rst
+++ b/README.rst
@@ -143,9 +143,6 @@ Run pytest tests on python code
    * - fail_on_codecov_error
      - false
      - Whether pipeline should fail if there would be an error on codecov side.
-   * - install_editable
-     - false
-     - Whether to install tested code in editable mode (pipenv only)
 
 
 .. list-table:: Configuration
@@ -257,13 +254,24 @@ release
             type: string
     jobs:
       release:
+        # The bump commit and the tag are pushed with the app token, not with
+        # the job's GITHUB_TOKEN, so reading is all this job needs.
         permissions:
-          contents: write
+          contents: read
         uses: fizyk/actions-reuse/.github/workflows/shared-release.yml@v5.4.1
         with:
           version: ${{ inputs.version }}
 
 Runs release on a repository. Requires tbump to be installed and configured in dependencies.
+
+The app token is minted with only the permissions the release needs, so the Github
+application has to grant all three: *Contents: write* for the bump commit and the tag,
+*Metadata: read*, and *Workflows: write*. The last one is requested unconditionally and
+minting the token fails without it, so it is required even when the repository keeps no
+workflows - a push touching ``.github/workflows`` is rejected without it anyway.
+
+The version passed in has to look like a version (``[0-9A-Za-z.+-]``): it reaches tbump
+through a shell command, and this workflow holds the release credentials.
 
 
 .. list-table:: Configuration

--- a/newsfragments/+drop-pipenv-editable.removal.rst
+++ b/newsfragments/+drop-pipenv-editable.removal.rst
@@ -1,0 +1,3 @@
+Drop the ``pipenv install --editable .`` step and the inputs that drove it: ``editable`` on the ``pipenv`` and ``pipenv-setup`` actions, ``install_editable`` on ``shared-tests-pytests``.
+A Pipfile says the same thing by itself - ``<project> = {path = ".", editable = true}`` under ``[packages]`` - so the input only duplicated it.
+Callers still passing it have to drop the line: a reusable workflow rejects an input it does not declare.

--- a/newsfragments/+zizmor-hardening.feature.rst
+++ b/newsfragments/+zizmor-hardening.feature.rst
@@ -1,0 +1,4 @@
+Mint ``shared-release``'s app token with just *Contents: write*, *Workflows: write* and *Metadata: read* instead of the whole installation's permissions, and declare ``permissions`` on the workflows in this repository.
+The release caller only needs ``contents: read`` now, as the bump commit and the tag have always been pushed with the app token; the documented snippet was updated accordingly.
+Inputs that name a path, a Python version or a step output reach their shell through the environment rather than through template expansion; the ``command`` and install-option inputs stay expanded, as callers rely on shell syntax inside them.
+``shared-release`` now refuses a ``version`` that is not one (``[0-9A-Za-z.+-]``) before minting the app token, as that input reaches tbump through a shell command.

--- a/newsfragments/313.feature.rst
+++ b/newsfragments/313.feature.rst
@@ -1,0 +1,2 @@
+Audit the workflows and composite actions with `zizmor <https://docs.zizmor.sh/>`__ on every pre-commit run.
+Its ``unpinned-uses`` policy allows tag references into ``fizyk/actions-reuse`` itself - a hash pin cannot name the commit that carries it - and requires a hash everywhere else; every other suppression sits inline next to the code it excuses.

--- a/tbump.toml
+++ b/tbump.toml
@@ -45,10 +45,6 @@ src = ".github/actions/coverage-combine-export/action.yml"
 [[file]]
 src = ".github/actions/coverage-combine-export-uv/action.yml"
 [[file]]
-src = ".github/workflows/pr-check.yml"
-[[file]]
-src = ".github/workflows/release.yml"
-[[file]]
 src = ".github/workflows/shared-pr-check.yml"
 [[file]]
 src = ".github/workflows/shared-pypi.yml"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Hardened automation workflows with read-only permissions and tightly scoped release credentials.
  - Added checks for unpinned workflow actions and unsafe command usage.
  - Improved handling of workflow inputs and credentials, including release-version validation.

- **Breaking Changes**
  - Removed editable-install options from Pipenv setup and testing workflows.

- **Documentation**
  - Updated action, testing, release, and security documentation to reflect the new configuration and permissions.
  - Added automated workflow security auditing to pre-commit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->